### PR TITLE
Support optimization using N1-methylpseudouridine with ViennaRNA

### DIFF
--- a/vaxpress/__main__.py
+++ b/vaxpress/__main__.py
@@ -189,6 +189,11 @@ def check_argument_validity(args):
         else:
             args.boost_loop_mutations = f'{boost_weight}:{boost_start}'
 
+    if args.m1psi and args.folding_engine == 'linearfold':
+        print('LinearFold currently does not support modified bases. '
+              'Remove --m1psi or use other folding engine supporting it.')
+        sys.exit(1)
+
 def parse_options(scoring_funcs, preset, default_off):
     parser = argparse.ArgumentParser(
         prog='vaxpress',
@@ -209,6 +214,9 @@ def parse_options(scoring_funcs, preset, default_off):
                      help='print top and bottom N sequences (default: 10)')
     grp.add_argument('--report-interval', type=int, default=5, metavar='MIN',
                      help='report interval in minutes (default: 5)')
+    grp.add_argument('--m1psi', default=False, action='store_true',
+                     help='substitute uridine with N1-methylpseudouridine (abbreviated \'1\'), '
+                          'only applicable for vienna folding engine')
     grp.add_argument('--version', action='version', version=__version__)
 
     grp = parser.add_argument_group('Execution Options')
@@ -345,6 +353,7 @@ def run_vaxpress():
         lineardesign_lambda=args.lineardesign,
         lineardesign_omit_start=args.lineardesign_omit_start,
         folding_engine=args.folding_engine,
+        m1psi=args.m1psi,
     )
 
     next_report = 0 # Generate the first report immediately.

--- a/vaxpress/evolution_chamber.py
+++ b/vaxpress/evolution_chamber.py
@@ -63,6 +63,7 @@ class CDSEvolutionChamber:
         self.n_processes = exec_options.processes
         self.quiet = exec_options.quiet
         self.print_top_mutants = exec_options.print_top_mutants
+        self.m1psi = exec_options.m1psi
 
         self.initialize()
 
@@ -385,8 +386,9 @@ class CDSEvolutionChamber:
         bestseq = ''.join(self.population[0])
         fastapath = os.path.join(self.outputdir, 'best-sequence.fasta')
         with open(fastapath, 'w') as f:
+            bestseq_output = bestseq.replace('U', '1') if self.m1psi else bestseq
             print(f'>{self.seq_description}', file=f)
-            print(*wrap(bestseq, width=self.fasta_line_width), sep='\n', file=f)
+            print(*wrap(bestseq_output, width=self.fasta_line_width), sep='\n', file=f)
 
         # Save the parameters used for the optimization
         paramspath = os.path.join(self.outputdir, 'parameters.json')

--- a/vaxpress/evolution_chamber.py
+++ b/vaxpress/evolution_chamber.py
@@ -29,11 +29,10 @@ import sys
 import os
 from textwrap import wrap
 from tabulate import tabulate
-from collections import namedtuple
 from concurrent import futures
 from itertools import cycle
 from .mutant_generator import MutantGenerator, STOP
-from .sequence_evaluator import SequenceEvaluator
+from .sequence_evaluator import SequenceEvaluator, ExecutionOptions
 from .presets import dump_to_preset
 from .log import hbar, hbar_double, log
 from . import __version__
@@ -41,15 +40,7 @@ from . import __version__
 PROTEIN_ALPHABETS = 'ACDEFGHIKLMNPQRSTVWY' + STOP
 RNA_ALPHABETS = 'ACGU'
 
-ExecutionOptions = namedtuple('ExecutionOptions', [
-    'n_iterations', 'n_population', 'n_survivors', 'initial_mutation_rate',
-    'winddown_trigger', 'winddown_rate', 'output', 'command_line', 'overwrite',
-    'seed', 'processes', 'random_initialization', 'conservative_start',
-    'boost_loop_mutations', 'full_scan_interval', 'species', 'codon_table',
-    'protein', 'quiet', 'seq_description', 'print_top_mutants', 'addons',
-    'lineardesign_dir', 'lineardesign_lambda', 'lineardesign_omit_start',
-    'folding_engine',
-])
+
 
 class CDSEvolutionChamber:
 

--- a/vaxpress/sequence_evaluator.py
+++ b/vaxpress/sequence_evaluator.py
@@ -28,14 +28,23 @@ import re
 import pylru
 from tqdm import tqdm
 from concurrent import futures
-from collections import Counter
+from collections import Counter, namedtuple
 from .log import hbar_stars, log
 
+ExecutionOptions = namedtuple('ExecutionOptions', [
+    'n_iterations', 'n_population', 'n_survivors', 'initial_mutation_rate',
+    'winddown_trigger', 'winddown_rate', 'output', 'command_line', 'overwrite',
+    'seed', 'processes', 'random_initialization', 'conservative_start',
+    'boost_loop_mutations', 'full_scan_interval', 'species', 'codon_table',
+    'protein', 'quiet', 'seq_description', 'print_top_mutants', 'addons',
+    'lineardesign_dir', 'lineardesign_lambda', 'lineardesign_omit_start',
+    'folding_engine',
+])
 
 class FoldEvaluator:
 
-    def __init__(self, engine: str):
-        self.engine = engine
+    def __init__(self, *, folding_engine: str, m1psi: bool, **rest: ExecutionOptions):
+        self.engine = folding_engine
         self.pat_find_loops = re.compile(r'\.{2,}')
         self.initialize()
 
@@ -126,7 +135,7 @@ class SequenceEvaluator:
         self.initialize()
 
     def initialize(self):
-        self.foldeval = FoldEvaluator(self.execopts.folding_engine)
+        self.foldeval = FoldEvaluator(**self.execopts._asdict())
         self.folding_cache = pylru.lrucache(self.folding_cache_size)
 
         self.scorefuncs_nofolding = []


### PR DESCRIPTION
## Summary

- This feature would be available after RNAFold(ViennaRNA) officially supports N1-methylpseudouridine
  - [Link to PR](https://github.com/ViennaRNA/ViennaRNA/pull/229)
- Substitutes every uridine to N1-methylpseudouridine if command line flag `--m1psi` is provided
  - Output sequence will contain `1` instead of `U`

## Checklist

- [x] `--folding-engine vienna` with `--m1psi` working
- [x] `--folding-engine vienna` without `--m1psi` working 
- [x] `--folding-engine linearfold` with `--m1psi` throws error (not supported)
- [x] `--folding-engine linearfold` without `--m1psi` working 