### PR TITLE
Report task information > sequence length to be correct with --protein

### DIFF
--- a/vaxpress/__main__.py
+++ b/vaxpress/__main__.py
@@ -368,7 +368,7 @@ def run_vaxpress():
                 status.update({'evaluations': evaldata, 'version': __version__})
 
                 generate_report(status, args, evochamber.metainfo, scoring_options,
-                                execution_options, inputseq, scoring_funcs)
+                                execution_options, inputseq, evochamber.bestseq, scoring_funcs)
 
         finished = (status is not None and status['iter_no'] < 0
                     and status['error'] == 0)
@@ -386,7 +386,7 @@ def run_vaxpress():
         return 1
 
 def generate_report(status, args, metainfo, scoring_options, execution_options,
-                    inputseq, scoring_funcs):
+                    inputseq, outputseq, scoring_funcs):
     if status['iter_no'] > 0: # Intermediate report
         total_elapsed = status['time'][-1] - status['time'][0]
         time_per_iteration = total_elapsed / status['iter_no']
@@ -402,7 +402,7 @@ def generate_report(status, args, metainfo, scoring_options, execution_options,
         status['refresh'] = args.report_interval * 60 + 5 # 5 seconds for safety
 
     ReportGenerator(status, args, metainfo, scoring_options, execution_options,
-                    inputseq, scoring_funcs).generate()
+                    inputseq, outputseq, scoring_funcs).generate()
 
 if __name__ == '__main__':
     ret = run_vaxpress()

--- a/vaxpress/evolution_chamber.py
+++ b/vaxpress/evolution_chamber.py
@@ -391,11 +391,11 @@ class CDSEvolutionChamber:
 
     def save_results(self):
         # Save the best sequence
-        bestseq = ''.join(self.population[0])
+        self.bestseq = ''.join(self.population[0])
         fastapath = os.path.join(self.outputdir, 'best-sequence.fasta')
         with open(fastapath, 'w') as f:
             print(f'>{self.seq_description}', file=f)
-            print(*wrap(bestseq, width=self.fasta_line_width), sep='\n', file=f)
+            print(*wrap(self.bestseq, width=self.fasta_line_width), sep='\n', file=f)
 
         # Save the parameters used for the optimization
         paramspath = os.path.join(self.outputdir, 'parameters.json')
@@ -404,7 +404,7 @@ class CDSEvolutionChamber:
         # Prepare the evaluation results of the best sequence
         return {
             'initial': self.initial_sequence_evaluation,
-            'optimized': self.seqeval.prepare_evaluation_data(bestseq)
+            'optimized': self.seqeval.prepare_evaluation_data(self.bestseq)
         }
 
     def save_optimization_parameters(self, path: str) -> None:

--- a/vaxpress/report_template/report.html
+++ b/vaxpress/report_template/report.html
@@ -47,7 +47,7 @@
 <h1>Task information</h1>
 <ul>
   <li><b>Sequence name:</b> {{ seq.description | e }}</li>
-  <li><b>Sequence length:</b> {{ seq.seq | length }} nt</li>
+  <li><b>Sequence length:</b> {{ outputseq | length }} nt</li>
   <li><b>Mutation space:</b> {{ metainfo['mutation_space']['singles'] }} types
     of mutations, {{ metainfo['mutation_space']['total'] | format_power_html }}
     combinations</li>

--- a/vaxpress/reporting.py
+++ b/vaxpress/reporting.py
@@ -163,9 +163,10 @@ class ReportPlotsMixin:
 
 class ReportGenerator(TemplateFiltersMixin, ReportPlotsMixin):
 
-    def __init__(self, status, args, metainfo, scoreopts, execopts, seq,
+    def __init__(self, status, args, metainfo, scoreopts, execopts, seq, outputseq,
                  scorefuncs):
         self.seq = seq
+        self.outputseq = outputseq
         self.args = args
         self.metainfo = metainfo
         self.status = status
@@ -195,6 +196,7 @@ class ReportGenerator(TemplateFiltersMixin, ReportPlotsMixin):
         return {
             'args': self.args,
             'seq': self.seq,
+            'outputseq': self.outputseq,
             'metainfo': self.metainfo,
             'scoring': scoreopts_filtered,
             'exec': self.execopts,


### PR DESCRIPTION
## Summary

- Corrected sequence length from task information section of report when using `--protein`
  - was emitting input seq length which is in amino acid, but the unit is fixed as `nt`
- Store bestseq as evolution chamber class attribute (refactor)

## Checklist

- [x] sequence length matches using `--protein`
- [x] sequence length matches not using `--protein`